### PR TITLE
Moved execa to dependencies to fix install issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,11 +34,11 @@
 	],
 	"dependencies": {
 		"meow": "^10.1.2",
-		"tempy": "^3.0.0"
+		"tempy": "^3.0.0",
+		"execa": "^6.1.0"
 	},
 	"devDependencies": {
 		"ava": "^4.3.0",
-		"execa": "^6.1.0",
 		"xo": "^0.49.0"
 	}
 }


### PR DESCRIPTION
Execa was located in `devDependencies` which means it was not being installed for regular users. I've now moved this to `dependencies`.